### PR TITLE
Treat KNAPSACK_GENERATE_REPORT=false as generate_report -> false

### DIFF
--- a/lib/knapsack/config/tracker.rb
+++ b/lib/knapsack/config/tracker.rb
@@ -11,7 +11,7 @@ module Knapsack
         end
 
         def generate_report
-          ENV['KNAPSACK_GENERATE_REPORT'] || false
+          !!(ENV['KNAPSACK_GENERATE_REPORT'] =~ /\Atrue|0\z/i)
         end
       end
     end

--- a/spec/knapsack/config/tracker_spec.rb
+++ b/spec/knapsack/config/tracker_spec.rb
@@ -13,8 +13,35 @@ describe Knapsack::Config::Tracker do
     subject { described_class.generate_report }
 
     context 'when ENV exists' do
-      before { stub_const("ENV", { 'KNAPSACK_GENERATE_REPORT' => true }) }
-      it { should be true }
+      it 'should be true when KNAPSACK_GENERATE_REPORT=true' do
+        with_env 'KNAPSACK_GENERATE_REPORT' => 'true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      it 'should be true when KNAPSACK_GENERATE_REPORT=0' do
+        with_env 'KNAPSACK_GENERATE_REPORT' => '0' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      it 'should be false when KNAPSACK_GENERATE_REPORT is ""' do
+        with_env 'KNAPSACK_GENERATE_REPORT' => '' do
+          expect(subject).to eq(false)
+        end
+      end
+
+      it 'should be false when KNAPSACK_GENERATE_REPORT is "false"' do
+        with_env 'KNAPSACK_GENERATE_REPORT' => 'false' do
+          expect(subject).to eq(false)
+        end
+      end
+
+      it 'should be false when KNAPSACK_GENERATE_REPORT is not "true" or "0"' do
+        with_env 'KNAPSACK_GENERATE_REPORT' => '1' do
+          expect(subject).to eq(false)
+        end
+      end
     end
 
     context "when ENV doesn't exist" do

--- a/spec/knapsack/tracker_spec.rb
+++ b/spec/knapsack/tracker_spec.rb
@@ -9,12 +9,9 @@ describe Knapsack::Tracker do
   it_behaves_like 'default trakcer attributes'
 
   describe '#config' do
-    before do
-      stub_const("ENV", { 'KNAPSACK_GENERATE_REPORT' => generate_report })
-    end
 
     context 'when passed options' do
-      let(:generate_report) { true }
+      let(:generate_report) { 'true' }
       let(:opts) do
         {
           enable_time_offset_warning: false,
@@ -23,12 +20,14 @@ describe Knapsack::Tracker do
       end
 
       it do
-        expect(tracker.config(opts)).to eql({
-          enable_time_offset_warning: false,
-          time_offset_in_seconds: 30,
-          generate_report: true,
-          fake: true
-        })
+        with_env 'KNAPSACK_GENERATE_REPORT' => generate_report do
+          expect(tracker.config(opts)).to eql({
+            enable_time_offset_warning: false,
+            time_offset_in_seconds: 30,
+            generate_report: true,
+            fake: true
+          })
+        end
       end
     end
 

--- a/spec/support/env_helper.rb
+++ b/spec/support/env_helper.rb
@@ -1,0 +1,13 @@
+module EnvHelper
+  def with_env(vars)
+    original = ENV.to_hash
+    vars.each { |k, v| ENV[k] = v }
+
+    begin
+      yield
+    ensure
+      ENV.replace(original)
+    end
+  end
+end
+RSpec.configuration.include EnvHelper


### PR DESCRIPTION
This commit changes the behavior of `generate_report` from checking for the presence of `ENV["KNAPSACK_GENERATE_REPORT"]` to checking whether the value of it is `true` or `0`. 

The upshot of this is that KNAPSACK_GENERATE_REPORT=false now means `generate_report` #=> false
